### PR TITLE
Don't raise ThreadError during shut down

### DIFF
--- a/lib/sidekiq/cloudwatchmetrics.rb
+++ b/lib/sidekiq/cloudwatchmetrics.rb
@@ -216,6 +216,9 @@ module Sidekiq::CloudWatchMetrics
       @stop = true
       @thread.wakeup
       @thread.join
+    rescue ThreadError
+      # Don't raise if thread is already dead.
+      nil
     end
   end
 end

--- a/spec/sidekiq/cloudwatchmetrics_spec.rb
+++ b/spec/sidekiq/cloudwatchmetrics_spec.rb
@@ -417,5 +417,17 @@ RSpec.describe Sidekiq::CloudWatchMetrics do
         end
       end
     end
+
+    describe "#stop" do
+      it "doesn't raise ThreadError" do
+        thread = double("thread", wakeup: true, join: true)
+        allow(thread).to receive(:wakeup).and_raise(ThreadError)
+        publisher.instance_variable_set("@thread", thread)
+
+        expect do
+          publisher.stop
+        end.not_to raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
If the system is shutting down, let it.